### PR TITLE
do not use JOBS=max on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi
   - export JOBS=max
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export JOBS=4; fi
 
 os:
   - osx


### PR DESCRIPTION
I suspect that g++ crashes because too many cores are used (32 on travis),
set to four instead