### PR TITLE
Deprecation warning on CompactRange

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -81,7 +81,8 @@ uint64_t Database::ApproximateSizeFromDatabase (const rocksdb::Range* range) {
 
 void Database::CompactRangeFromDatabase (const rocksdb::Slice* start,
                                          const rocksdb::Slice* end) {
-  db->CompactRange(start, end);
+  const rocksdb::CompactRangeOptions options;
+  db->CompactRange(options, start, end);
 }
 
 void Database::GetPropertyFromDatabase (

--- a/src/database.cc
+++ b/src/database.cc
@@ -81,7 +81,7 @@ uint64_t Database::ApproximateSizeFromDatabase (const rocksdb::Range* range) {
 
 void Database::CompactRangeFromDatabase (const rocksdb::Slice* start,
                                          const rocksdb::Slice* end) {
-  const rocksdb::CompactRangeOptions options;
+  rocksdb::CompactRangeOptions options;
   db->CompactRange(options, start, end);
 }
 


### PR DESCRIPTION
After compiling get deprecation warning on CompactRange method call. 
```
../src/database.cc:84:7: warning: 'CompactRange' is deprecated [-Wdeprecated-declarations]
  db->CompactRange(start, end);
      ^
../deps/leveldb/leveldb-rocksdb/include/rocksdb/db.h:709:42: note: 'CompactRange' has been
      explicitly marked deprecated here
  ROCKSDB_DEPRECATED_FUNC virtual Status CompactRange(
                                         ^
1 warning generated.
```
![schermata 2017-06-02 alle 00 31 04](https://cloud.githubusercontent.com/assets/387506/26707650/949b8b6e-4746-11e7-8335-97c86c54acc2.png)
Now i created the CompactRangeOptions with default value and passed it to CompactRange method.