### PR TITLE
Add sys/sysmacros.h for build on modern glibc

### DIFF
--- a/deps/leveldb/leveldb-rocksdb/util/io_posix.cc
+++ b/deps/leveldb/leveldb-rocksdb/util/io_posix.cc
@@ -25,6 +25,7 @@
 #ifdef OS_LINUX
 #include <sys/statfs.h>
 #include <sys/syscall.h>
+#include <sys/sysmacros.h>
 #endif
 #include "port/port.h"
 #include "rocksdb/slice.h"


### PR DESCRIPTION
Port of https://github.com/facebook/rocksdb/pull/2208/files

Without this, `npm i rocksdb` fails on my arch linux machine.

glibc version:
```
Version         : 2.28-5
Build Date      : Thu 11 Oct 2018 01:18:28 AM PDT
Install Date    : Wed 24 Oct 2018 10:43:56 PM PDT
```

Error:
```
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-rocksdb/util/iostats_context.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-rocksdb/util/io_posix.o
../deps/leveldb/leveldb-rocksdb/util/io_posix.cc: In function ‘size_t rocksdb::{anonymous}::GetLogicalBufferSize(int)’:
../deps/leveldb/leveldb-rocksdb/util/io_posix.cc:57:7: error: ‘major’ was not declared in this scope
   if (major(buf.st_dev) == 0) {
       ^~~~~
../deps/leveldb/leveldb-rocksdb/util/io_posix.cc:67:55: error: ‘major’ was not declared in this scope
   snprintf(path, kBufferSize, "/sys/dev/block/%u:%u", major(buf.st_dev),
                                                       ^~~~~
../deps/leveldb/leveldb-rocksdb/util/io_posix.cc:68:12: error: ‘minor’ was not declared in this scope
            minor(buf.st_dev));
            ^~~~~
../deps/leveldb/leveldb-rocksdb/util/io_posix.cc:68:12: note: suggested alternative: ‘mknod’
            minor(buf.st_dev));
            ^~~~~
            mknod
make: *** [deps/leveldb/leveldb.target.mk:299: Release/obj.target/leveldb/deps/leveldb/leveldb-rocksdb/util/io_posix.o] Error 1
make: Leaving directory '/home/eswanson/projects/rockdove/node_modules/rocksdb/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:254:12)
gyp ERR! System Linux 4.19.4-arch1-1-ARCH
gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/eswanson/projects/rockdove/node_modules/rocksdb
gyp ERR! node -v v11.2.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok 
npm WARN ts-mock-imports@1.2.2 requires a peer of typescript@>=2.6.1 < 3.2 but none is installed. You must install peer dependencies yourself.
npm WARN ts-mock-imports@1.2.2 requires a peer of sinon@>= 4.1.2 < 7 but none is installed. You must install peer dependencies yourself.
npm WARN rockdove@0.0.1 No repository field.
npm WARN rockdove@0.0.1 No license field.
```