### PR TITLE
Read only support for rocksdb

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -43,7 +43,7 @@ public:
   static void Init ();
   static v8::Local<v8::Value> NewInstance (v8::Local<v8::String> &location);
 
-  rocksdb::Status OpenDatabase (rocksdb::Options* options);
+  rocksdb::Status OpenDatabase (rocksdb::Options* options, bool readOnly);
   rocksdb::Status PutToDatabase (
       rocksdb::WriteOptions* options
     , rocksdb::Slice key

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -36,7 +36,9 @@ OpenWorker::OpenWorker (
   , uint32_t maxOpenFiles
   , uint32_t blockRestartInterval
   , uint32_t maxFileSize
+  , bool readOnly
 ) : AsyncWorker(database, callback, "rocksdb:db.open")
+  , readOnly_(readOnly)
 {
   rocksdb::LevelDBOptions levelOptions;
 
@@ -85,7 +87,7 @@ OpenWorker::~OpenWorker () {
 }
 
 void OpenWorker::Execute () {
-  SetStatus(database->OpenDatabase(options));
+  SetStatus(database->OpenDatabase(options, readOnly_));
 }
 
 /** CLOSE WORKER **/

--- a/src/database_async.h
+++ b/src/database_async.h
@@ -25,6 +25,7 @@ public:
     , uint32_t maxOpenFiles
     , uint32_t blockRestartInterval
     , uint32_t maxFileSize
+    , bool readOnly
   );
 
   virtual ~OpenWorker ();
@@ -32,6 +33,7 @@ public:
 
 private:
   rocksdb::Options* options;
+  bool readOnly_;
 };
 
 class CloseWorker : public AsyncWorker {

--- a/test/open-read-only-test.js
+++ b/test/open-read-only-test.js
@@ -4,7 +4,17 @@ const test = require('tape')
 const leveldown = require('../')
 const testCommon = require('abstract-leveldown/testCommon')
 const fs = require('fs')
+const path = require('path')
+
 var location = testCommon.location()
+
+function chmodFilesSync (dir, mode) {
+  var files = fs.readdirSync(dir)
+  files.forEach(function (file) {
+    var fullPath = path.join(dir, file)
+    fs.chmodSync(fullPath, mode)
+  })
+}
 
 test('setUp', function (t) {
   // just in case we thew an error last time and don't have perms to remove db
@@ -30,6 +40,7 @@ test('test write to read/write database', function (t) {
 })
 
 test('test throw error reading read-only database', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open(function (err) {
@@ -40,6 +51,7 @@ test('test throw error reading read-only database', function (t) {
 })
 
 test('test read from a read-only database if readOnly is true', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open({ readOnly: true }, function (err) {
@@ -53,6 +65,7 @@ test('test read from a read-only database if readOnly is true', function (t) {
 })
 
 test('test throw error reading read-only database if readOnly is false', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open({ readOnly: false }, function (err) {
@@ -63,6 +76,7 @@ test('test throw error reading read-only database if readOnly is false', functio
 })
 
 test('test throw error putting data to read-only db if readOnly is true', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open({ readOnly: true }, function (err) {
@@ -76,6 +90,7 @@ test('test throw error putting data to read-only db if readOnly is true', functi
 })
 
 test('test throw error deleting data from read-only db if readOnly is true', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open({ readOnly: true }, function (err) {
@@ -89,6 +104,7 @@ test('test throw error deleting data from read-only db if readOnly is true', fun
 })
 
 test('test throw error with batch put from read-only db if readOnly is true', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open({ readOnly: true }, function (err) {
@@ -102,6 +118,7 @@ test('test throw error with batch put from read-only db if readOnly is true', fu
 })
 
 test('test throw error with batch del from read-only db if readOnly is true', function (t) {
+  chmodFilesSync(location, 0o555)
   fs.chmodSync(location, 0o555)
   var db = leveldown(location)
   db.open({ readOnly: true }, function (err) {

--- a/test/open-read-only-test.js
+++ b/test/open-read-only-test.js
@@ -103,34 +103,6 @@ test('test throw error deleting data from read-only db if readOnly is true', fun
   })
 })
 
-test('test throw error with batch put from read-only db if readOnly is true', function (t) {
-  chmodFilesSync(location, 0o555)
-  fs.chmodSync(location, 0o555)
-  var db = leveldown(location)
-  db.open({ readOnly: true }, function (err) {
-    t.error(err)
-    db.batch([{ key: 'key 1', type: 'put', value: 'value 1' }], function (err) {
-      t.ok(err, 'should get write error')
-      t.ok(/Not supported operation in read only mode/i.test(err && err.message), 'should get io error')
-      db.close(t.end.bind(t))
-    })
-  })
-})
-
-test('test throw error with batch del from read-only db if readOnly is true', function (t) {
-  chmodFilesSync(location, 0o555)
-  fs.chmodSync(location, 0o555)
-  var db = leveldown(location)
-  db.open({ readOnly: true }, function (err) {
-    t.error(err)
-    db.batch([{ key: 'my key', type: 'del' }], function (err) {
-      t.ok(err, 'should get write error')
-      t.ok(/Not supported operation in read only mode/i.test(err && err.message), 'should get io error')
-      db.close(t.end.bind(t))
-    })
-  })
-})
-
 test('tearDown', function (t) {
   // just in case we thew an error last time and don't have perms to remove db
   if (fs.existsSync(location)) {

--- a/test/open-read-only-test.js
+++ b/test/open-read-only-test.js
@@ -8,6 +8,7 @@ const path = require('path')
 
 var location = testCommon.location()
 
+// This is used because it's not sufficient on windows to set a parent folder as readonly
 function chmodFilesSync (dir, mode) {
   var files = fs.readdirSync(dir)
   files.forEach(function (file) {
@@ -20,6 +21,7 @@ test('setUp', function (t) {
   // just in case we thew an error last time and don't have perms to remove db
   if (fs.existsSync(location)) {
     fs.chmodSync(location, 0o755)
+    chmodFilesSync(location, 0o755)
   }
   testCommon.setUp(t)
 })
@@ -107,6 +109,7 @@ test('tearDown', function (t) {
   // just in case we thew an error last time and don't have perms to remove db
   if (fs.existsSync(location)) {
     fs.chmodSync(location, 0o755)
+    chmodFilesSync(location, 0o755)
   }
   testCommon.tearDown(t)
 })

--- a/test/open-read-only-test.js
+++ b/test/open-read-only-test.js
@@ -1,0 +1,123 @@
+'use strict'
+
+const test = require('tape')
+const leveldown = require('../')
+const testCommon = require('abstract-leveldown/testCommon')
+const fs = require('fs')
+var location = testCommon.location()
+
+test('setUp', function (t) {
+  // just in case we thew an error last time and don't have perms to remove db
+  if (fs.existsSync(location)) {
+    fs.chmodSync(location, 0o755)
+  }
+  testCommon.setUp(t)
+})
+
+test('test write to read/write database', function (t) {
+  var db = leveldown(location)
+  db.open(function (err) {
+    t.error(err)
+    db.put('my key', 'my value', function (err) {
+      t.error(err, 'no write error')
+      db.get('my key', function (err, value) {
+        t.error(err, 'no read error')
+        t.equal(value.toString(), 'my value', 'correct value')
+        db.close(t.end.bind(t))
+      })
+    })
+  })
+})
+
+test('test throw error reading read-only database', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open(function (err) {
+    t.ok(err, 'should get error reading read only database')
+    t.ok(/IO Error/i.test(err && err.message), 'should get io error')
+    db.close(t.end.bind(t))
+  })
+})
+
+test('test read from a read-only database if readOnly is true', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open({ readOnly: true }, function (err) {
+    t.error(err)
+    db.get('my key', function (err, value) {
+      t.error(err, 'no read error')
+      t.equal(value.toString(), 'my value', 'correct value')
+      db.close(t.end.bind(t))
+    })
+  })
+})
+
+test('test throw error reading read-only database if readOnly is false', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open({ readOnly: false }, function (err) {
+    t.ok(err, 'should get error reading read only database')
+    t.ok(/IO Error/i.test(err && err.message), 'should get io error')
+    db.close(t.end.bind(t))
+  })
+})
+
+test('test throw error putting data to read-only db if readOnly is true', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open({ readOnly: true }, function (err) {
+    t.error(err)
+    db.put('my key', 'my value', function (err) {
+      t.ok(err, 'should get write error')
+      t.ok(/Not supported operation in read only mode/i.test(err && err.message), 'should get io error')
+      db.close(t.end.bind(t))
+    })
+  })
+})
+
+test('test throw error deleting data from read-only db if readOnly is true', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open({ readOnly: true }, function (err) {
+    t.error(err)
+    db.del('my key', function (err) {
+      t.ok(err, 'should get write error')
+      t.ok(/Not supported operation in read only mode/i.test(err && err.message), 'should get io error')
+      db.close(t.end.bind(t))
+    })
+  })
+})
+
+test('test throw error with batch put from read-only db if readOnly is true', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open({ readOnly: true }, function (err) {
+    t.error(err)
+    db.batch([{ key: 'key 1', type: 'put', value: 'value 1' }], function (err) {
+      t.ok(err, 'should get write error')
+      t.ok(/Not supported operation in read only mode/i.test(err && err.message), 'should get io error')
+      db.close(t.end.bind(t))
+    })
+  })
+})
+
+test('test throw error with batch del from read-only db if readOnly is true', function (t) {
+  fs.chmodSync(location, 0o555)
+  var db = leveldown(location)
+  db.open({ readOnly: true }, function (err) {
+    t.error(err)
+    db.batch([{ key: 'my key', type: 'del' }], function (err) {
+      t.ok(err, 'should get write error')
+      t.ok(/Not supported operation in read only mode/i.test(err && err.message), 'should get io error')
+      db.close(t.end.bind(t))
+    })
+  })
+})
+
+test('tearDown', function (t) {
+  // just in case we thew an error last time and don't have perms to remove db
+  if (fs.existsSync(location)) {
+    fs.chmodSync(location, 0o755)
+  }
+  testCommon.tearDown(t)
+})


### PR DESCRIPTION
This PR adds read only rocksdb support.

This PR closes #72 and quite a few comments on #13 

There's a new `readOnly` boolean option to the database options object that can be used to open a rocksdb database in readonly mode.

I've also included some tests which use `chmod` to set the database to read only to set the various edge cases.

I've also published a version to `@eugeneware/rocksdb` in case this doesn't get merged for a while for people to use.

