### PR TITLE
Prepare next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased][unreleased]
 
+## [3.1.0] - 2019-04-21
+
+### Changed
+
+- Upgrade `bindings` from `~1.3.0` to `~1.5.0` ([#95](https://github.com/level/rocksdb/issues/95)) ([**@vweevers**](https://github.com/vweevers))
+- Upgrade `nan` from `~2.11.0` to `~2.13.2` ([#89](https://github.com/level/rocksdb/issues/89), [#97](https://github.com/level/rocksdb/issues/97)) ([**@vweevers**](https://github.com/vweevers))
+- Upgrade `nyc` devDependency from `^12.0.2` to `^13.2.0` ([#92](https://github.com/level/rocksdb/issues/92)) ([**@vweevers**](https://github.com/vweevers))
+- Apply common project tweaks ([#90](https://github.com/level/rocksdb/issues/90), [#91](https://github.com/level/rocksdb/issues/91)) ([**@vweevers**](https://github.com/vweevers))
+
+### Added
+
+- Add `readOnly` option ([#98](https://github.com/level/rocksdb/issues/98)) ([**@eugeneware**](https://github.com/eugeneware))
+
+### Removed
+
+- Remove `prebuild` script from `package.json` ([#102](https://github.com/level/rocksdb/issues/102)) ([**@vweevers**](https://github.com/vweevers))
+- Remove link to dead website ([`2430b09`](https://github.com/level/rocksdb/commit/2430b09)) ([**@vweevers**](https://github.com/vweevers))
+
+### Fixed
+
+- Fix subtests by adding `t.plan()` ([#94](https://github.com/level/rocksdb/issues/94)) ([**@vweevers**](https://github.com/vweevers))
+- Gitignore debug builds of dependencies ([#101](https://github.com/level/rocksdb/issues/101)) ([**@vweevers**](https://github.com/vweevers))
+- Npmignore Windows builds, RocksDB docs, tools and more ([#101](https://github.com/level/rocksdb/issues/101)) ([**@vweevers**](https://github.com/vweevers))
+
 ## [3.0.3] - 2018-12-09
 
 ### Changed
@@ -105,7 +129,9 @@
 
 **Historical Note** Earlier versions were published before `v1.0.0` but the code was then a branch inside [`leveldown`](https://github.com/level/leveldown). This version marks the point where that code was extracted into its own repository thanks to the work of [`@mcollina`](https://github.com/mcollina).
 
-[unreleased]: https://github.com/level/rocksdb/compare/v3.0.3...HEAD
+[unreleased]: https://github.com/level/rocksdb/compare/v3.1.0...HEAD
+
+[3.1.0]: https://github.com/level/rocksdb/compare/v3.0.3...v3.1.0
 
 [3.0.3]: https://github.com/level/rocksdb/compare/v3.0.2...v3.0.3
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,13 +26,14 @@
 | **Amine Mouafik**       | [**@kytwb**](https://github.com/kytwb)                 |                                                                          |
 | **James Butler**        | [**@sandfox**](https://github.com/sandfox)             |                                                                          |
 | **Andrew Kelley**       | [**@andrewrk**](https://github.com/andrewrk)           |                                                                          |
-| **Eric Swanson**        |                                                        |                                                                          |
+| **Eugene Ware**         |                                                        |                                                                          |
+| **Aaron Bieber**        | [**@qbit**](https://github.com/qbit)                   |                                                                          |
 | **Anton Whalley**       | [**@no9**](https://github.com/no9)                     | [**@dhigit9@twitter**](https://twitter.com/dhigit9)                      |
 | **Tim Kuijsten**        | [**@timkuijsten**](https://github.com/timkuijsten)     | [**@timkuijsten@mastodon.social**](https://mastodon.social/@timkuijsten) |
 | **Michael Nisi**        | [**@michaelnisi**](https://github.com/michaelnisi)     |                                                                          |
 | **Sharvil Nanavati**    | [**@sharvil**](https://github.com/sharvil)             |                                                                          |
 | **Thorsten Lorenz**     | [**@thlorenz**](https://github.com/thlorenz)           |                                                                          |
-| **Aaron Bieber**        | [**@qbit**](https://github.com/qbit)                   |                                                                          |
+| **Eric Swanson**        |                                                        |                                                                          |
 | **Adam Bliss**          | [**@abliss**](https://github.com/abliss)               |                                                                          |
 | **flames of love**      |                                                        |                                                                          |
 | **mscdex**              | [**@mscdex**](https://github.com/mscdex)               |                                                                          |


### PR DESCRIPTION
Version TBD. Depending on review of open PRs, we can go one of 4 ways:

1. ~~Release 3.1.0 now (semver-minor due to #98)~~
1. Land #101 and #102, release 3.1.0
2. ~~Land the above and #77, release 4.0.0 (major due to `abstract-leveldown` upgrade)~~
3. ~~Land the above and rewrite as N-API (#100, it's not a big task), release 4.0.0~~