### PR TITLE
Disable info log by default and add infoLogLevel option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ prebuilds/
 yarn.lock
 package-lock.json
 .nyc_output/
+.benchmarks/

--- a/.npmignore
+++ b/.npmignore
@@ -42,6 +42,7 @@ libleveldb.a
 # Benchmarks and tests
 bench/
 test/
+.benchmarks/
 *.csv
 
 # Misc

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you don't want to use the prebuilt binary for the platform you are installing
 Please refer to [`leveldown`](https://github.com/Level/leveldown#api) for API documentation. The `db.open(options, callback)` method of `rocksdb` has a few additional options:
 
 - `readOnly` (boolean, default `false`): open database in read-only mode.
+- `infoLogLevel` (string, default `null`): verbosity of info log. One of `'debug'`, `'info'`, `'warn'`, `'error'`, `'fatal'`, `'header'` or `null` (disable).
 
 ## Contributing
 

--- a/leveldown.js
+++ b/leveldown.js
@@ -3,7 +3,6 @@ const AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
 const binding = require('./binding')
 const ChainedBatch = require('./chained-batch')
 const Iterator = require('./iterator')
-const fs = require('fs')
 
 function LevelDOWN (location) {
   if (!(this instanceof LevelDOWN)) {
@@ -122,28 +121,7 @@ LevelDOWN.destroy = function (location, callback) {
     throw new Error('destroy() requires a callback function argument')
   }
 
-  binding.destroy_db(location, function (err) {
-    if (err) return callback(err)
-
-    // On Windows, RocksDB silently fails to remove the directory because its
-    // Logger, which is instantiated on destroy(), has an open file handle on a
-    // LOG file. Destroy() removes this file but Windows won't actually delete
-    // it until the handle is released. This happens when destroy() goes out of
-    // scope, which disposes the Logger. So back in JS-land, we can again
-    // attempt to remove the directory. This is merely a workaround because
-    // arguably RocksDB should not instantiate a Logger or open a file at all.
-    fs.rmdir(location, function (err) {
-      if (err) {
-        // Ignore this error in case there are non-RocksDB files left.
-        if (err.code === 'ENOTEMPTY') return callback()
-        if (err.code === 'ENOENT') return callback()
-
-        return callback(err)
-      }
-
-      callback()
-    })
-  })
+  binding.destroy_db(location, callback)
 }
 
 LevelDOWN.repair = function (location, callback) {

--- a/test/destroy-test.js
+++ b/test/destroy-test.js
@@ -38,7 +38,8 @@ test('test destroy non-existent directory', function (t) {
     t.ifError(err, 'no error from rimraf()')
 
     leveldown.destroy(location, function (err) {
-      t.error(err, 'no error')
+      // This behavior differs from LevelDB, which is silent.
+      t.ok(/.*IO error.*/.test(err), 'got IO error')
 
       // Assert that destroy() didn't inadvertently create the directory.
       // Or if it did, that it was at least cleaned up afterwards.


### PR DESCRIPTION
Closes #113.

Benchmarks show that this doesn't improve write performance (with the info log enabled, there's a small amount of logs being written on every compaction). It does however fix the `destroy()` bug on Windows in a cleaner way, and prevents endlessly growing logs that you didn't ask for (cc @MeirionHughes).

```
git checkout disable-info-log
level-bench run write -b [-n 2e6 --concurrency 10]
level-bench run write -b [-n 2e6 --concurrency 10] --db [--infoLogLevel debug]
level-bench plot write
```

![write 1558886671306](https://user-images.githubusercontent.com/3055345/58384612-e18e1680-7fe3-11e9-959b-3bfdb59a0f02.png)
