### PR TITLE
use napi_create_int64 for approximate size

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1077,7 +1077,7 @@ struct ApproximateSizeWorker final : public PriorityWorker {
   void HandleOKCallback () override {
     napi_value argv[2];
     napi_get_null(env_, &argv[0]);
-    napi_create_uint32(env_, (uint32_t)size_, &argv[1]);
+    napi_create_int64(env_, (int64_t)size_, &argv[1]);
     napi_value callback;
     napi_get_reference_value(env_, callbackRef_, &callback);
     CallFunction(env_, callback, 2, argv);


### PR DESCRIPTION
The PR is a port of [this change](https://github.com/Level/leveldown/pull/777) from Level/leveldown.

Currently the binding for `approximateSize` stores the result as `uint32`. This supports only databases of up to 4GB and returns wrong results for larger DBs. 

The PR changes the code to use the full `uint64` that is returned from RocksDB and converts it to a Javascript number using `napi_create_int64`. The result is approximate for values that do not satisfy `Number.isSafeInteger()`. This should be fine because the original value returned by RocksDB is "approximate" in first place.

