### PR TITLE
Build a universal binary to support M1 (Apple silicon)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,9 @@ jobs:
         include:
           - os: ubuntu-latest
             build-group: linux-x64
-          - os: macos-latest
-            build-group: darwin-x64
+          # At the time of writing macos-latest is mac 10; we need 11 to build a universal binary.
+          - os: macos-11
+            build-group: darwin-x64+arm64
           - os: windows-latest
             build-group: win32-x64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # At the time of writing macos-latest is mac 10; we need 11 to build a universal binary.
+        os: [ubuntu-latest, macos-11, windows-latest]
         node: [10, 12, 14]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Node ${{ matrix.node }}

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,14 +38,20 @@
                   , '-Wno-ignored-qualifiers'
                 ]
                 , 'OTHER_CPLUSPLUSFLAGS': [
-                    '-mmacosx-version-min=10.8'
+                    '-mmacosx-version-min=10.12'
                   , '-std=c++11'
                   , '-stdlib=libc++'
+                  , '-arch x86_64'
+                  , '-arch arm64'
                 ]
-                , 'OTHER_LDFLAGS': ['-stdlib=libc++']
+                , 'OTHER_LDFLAGS': [
+                    '-stdlib=libc++'
+                  , '-arch x86_64'
+                  , '-arch arm64'
+                ]
                 , 'GCC_ENABLE_CPP_RTTI': 'YES'
                 , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-                , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
+                , 'MACOSX_DEPLOYMENT_TARGET': '10.12'
             }
           }]
         , ['OS == "linux"', {

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,7 +38,7 @@
                   , '-Wno-ignored-qualifiers'
                 ]
                 , 'OTHER_CPLUSPLUSFLAGS': [
-                    '-mmacosx-version-min=10.12'
+                    '-mmacosx-version-min=10.8'
                   , '-std=c++11'
                   , '-stdlib=libc++'
                   , '-arch x86_64'
@@ -51,7 +51,7 @@
                 ]
                 , 'GCC_ENABLE_CPP_RTTI': 'YES'
                 , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-                , 'MACOSX_DEPLOYMENT_TARGET': '10.12'
+                , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
             }
           }]
         , ['OS == "linux"', {

--- a/deps/rocksdb/rocksdb.gyp
+++ b/deps/rocksdb/rocksdb.gyp
@@ -173,6 +173,14 @@
                 , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
             }
         }]
+      , ['target_arch == "arm64" or target_arch == "aarch64"', {
+          'sources': [
+            'rocksdb/util/crc32c_arm64.cc'
+          ]
+        , 'ccflags': [
+            '-march=armv8-a+crc+crypto'
+          ]
+        }]
     ]
   , 'sources': [
         'rocksdb/cache/cache.cc'

--- a/deps/rocksdb/rocksdb.gyp
+++ b/deps/rocksdb/rocksdb.gyp
@@ -147,7 +147,10 @@
             ]
         }]
       , ['OS == "mac"', {
-            'defines': [
+            'sources': [
+                'rocksdb/util/crc32c_arm64.cc'
+             ]
+          , 'defines': [
                 'OS_MACOSX=1',
                 'ROCKSDB_LIB_IO_POSIX=1',
                 'ROCKSDB_BACKTRACE=1'
@@ -161,16 +164,18 @@
                   , '-Wno-unused-function'
                 ]
                 , 'OTHER_CPLUSPLUSFLAGS': [
-                    '-mmacosx-version-min=10.8'
+                    '-mmacosx-version-min=10.12'
                   , '-std=c++11'
                   , '-stdlib=libc++'
                   , '-fno-omit-frame-pointer'
                   , '-momit-leaf-frame-pointer'
+                  , '-arch x86_64'
+                  , '-arch arm64'
                 ]
 # , 'OTHER_LDFLAGS': ['-stdlib=libc++']
                 , 'GCC_ENABLE_CPP_RTTI': 'YES'
                 , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-                , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
+                , 'MACOSX_DEPLOYMENT_TARGET': '10.12'
             }
         }]
       , ['target_arch == "arm64" or target_arch == "aarch64"', {

--- a/deps/rocksdb/rocksdb.gyp
+++ b/deps/rocksdb/rocksdb.gyp
@@ -147,10 +147,7 @@
             ]
         }]
       , ['OS == "mac"', {
-            'sources': [
-                'rocksdb/util/crc32c_arm64.cc'
-             ]
-          , 'defines': [
+            'defines': [
                 'OS_MACOSX=1',
                 'ROCKSDB_LIB_IO_POSIX=1',
                 'ROCKSDB_BACKTRACE=1'
@@ -177,14 +174,6 @@
                 , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
                 , 'MACOSX_DEPLOYMENT_TARGET': '10.12'
             }
-        }]
-      , ['target_arch == "arm64" or target_arch == "aarch64"', {
-          'sources': [
-            'rocksdb/util/crc32c_arm64.cc'
-          ]
-        , 'ccflags': [
-            '-march=armv8-a+crc+crypto'
-          ]
         }]
     ]
   , 'sources': [
@@ -389,6 +378,7 @@
       , 'rocksdb/util/compression_context_cache.cc'
       , 'rocksdb/util/concurrent_task_limiter_impl.cc'
       , 'rocksdb/util/crc32c.cc'
+      , 'rocksdb/util/crc32c_arm64.cc'
       , 'rocksdb/util/dynamic_bloom.cc'
       , 'rocksdb/util/hash.cc'
       , 'rocksdb/util/murmurhash.cc'

--- a/deps/rocksdb/rocksdb.gyp
+++ b/deps/rocksdb/rocksdb.gyp
@@ -161,7 +161,7 @@
                   , '-Wno-unused-function'
                 ]
                 , 'OTHER_CPLUSPLUSFLAGS': [
-                    '-mmacosx-version-min=10.12'
+                    '-mmacosx-version-min=10.8'
                   , '-std=c++11'
                   , '-stdlib=libc++'
                   , '-fno-omit-frame-pointer'
@@ -172,7 +172,7 @@
 # , 'OTHER_LDFLAGS': ['-stdlib=libc++']
                 , 'GCC_ENABLE_CPP_RTTI': 'YES'
                 , 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-                , 'MACOSX_DEPLOYMENT_TARGET': '10.12'
+                , 'MACOSX_DEPLOYMENT_TARGET': '10.8'
             }
         }]
     ]

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -71,6 +71,10 @@
                     '-Wno-sign-compare'
                   , '-Wno-unused-function'
                 ]
+	      , 'OTHER_CFLAGS': [
+	            '-arch x86_64'
+		  , '-arch arm64'
+		]
             }
         }]
     ]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "rebuild": "npm run install --build-from-source",
     "prebuild": "prebuildify -t 8.14.0 --napi --strip",
     "prebuild-linux-x64": "prebuildify-cross -i centos7-devtoolset7 -i alpine -t 8.14.0 --napi --strip",
-    "prebuild-darwin-x64": "prebuildify -t 8.14.0 --napi --strip",
+    "prebuild-darwin-x64+arm64": "prebuildify -t 8.14.0 --napi --strip --arch x64+arm64",
     "prebuild-win32-x64": "prebuildify -t 8.14.0 --napi --strip",
     "download-prebuilds": "prebuildify-ci download",
     "hallmark": "hallmark --fix",
@@ -24,7 +24,7 @@
   "dependencies": {
     "abstract-leveldown": "^7.0.0",
     "napi-macros": "^2.0.0",
-    "node-gyp-build": "^4.2.3"
+    "node-gyp-build": "^4.3.0"
   },
   "devDependencies": {
     "async-each": "^1.0.3",
@@ -40,7 +40,7 @@
     "mkfiletree": "^2.0.0",
     "node-gyp": "^7.1.2",
     "nyc": "^15.0.0",
-    "prebuildify": "^4.1.1",
+    "prebuildify": "^4.2.1",
     "prebuildify-ci": "^1.0.4",
     "prebuildify-cross": "^4.0.1",
     "readfiletree": "^1.0.0",


### PR DESCRIPTION
Closes #177 

Since this change is around cpu architecture and not OS, I did some testing on Ubuntu ARM64. Interestingly, 5.1.0 here did not have the same issue as on the Mac M1. Nevertheless, I've tested this PR on the M1 Mac and Ubuntu ARM64, have not encountered any errors and, so far, it's working well in our app (though the more eyeballs, the better - if @buu700 is able to give this a try as well :pray: ) 