### PR TITLE
Fix `getMany()` memory leak

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -274,6 +274,7 @@ static std::vector<std::string>* KeyArray (napi_env env, napi_value arr) {
           StringOrBufferLength(env, element) > 0) {
         LD_STRING_OR_BUFFER_TO_COPY(env, element, to);
         result->emplace_back(toCh_, toSz_);
+        delete [] toCh_;
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/Level/rocksdb/issues/192
Ref https://github.com/Level/leveldown/issues/790