### PR TITLE
Add scripts for linux-arm64 prebuilds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            build-group: linux-arm64
+          - os: ubuntu-latest
             build-group: linux-x64
           # At the time of writing macos-latest is mac 10; we need 11 to build a universal binary.
           - os: macos-11

--- a/binding.gyp
+++ b/binding.gyp
@@ -69,5 +69,8 @@
       , "sources": [
             "binding.cc"
         ]
-    }]
+    }],
+    "variables": {
+        "openssl_fips": ""
+    }
 }

--- a/deps/rocksdb/rocksdb.gyp
+++ b/deps/rocksdb/rocksdb.gyp
@@ -472,4 +472,8 @@
 
       , 'build_version.cc'
     ]
-}]}
+  }],
+  'variables': {
+    'openssl_fips': ''
+  }
+}

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -87,4 +87,8 @@
       , 'snappy-1.1.7/snappy.cc'
       , 'snappy-1.1.7/snappy.h'
     ]
-}]}
+  }],
+  'variables': {
+    'openssl_fips': ''
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "nyc report -r lcovonly",
     "rebuild": "npm run install --build-from-source",
     "prebuild": "prebuildify -t 8.14.0 --napi --strip",
-    "prebuild-linux-arm64": "prebuildify-cross -i linux-arm64 -t 8.14.0 --napi --strip",
+    "prebuild-linux-arm64": "prebuildify-cross -i linux-arm64-lts -t 8.14.0 --napi --strip",
     "prebuild-linux-x64": "prebuildify-cross -i centos7-devtoolset7 -i alpine -t 8.14.0 --napi --strip",
     "prebuild-darwin-x64+arm64": "prebuildify -t 8.14.0 --napi --strip --arch x64+arm64",
     "prebuild-win32-x64": "prebuildify -t 8.14.0 --napi --strip",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "coverage": "nyc report -r lcovonly",
     "rebuild": "npm run install --build-from-source",
     "prebuild": "prebuildify -t 8.14.0 --napi --strip",
+    "prebuild-linux-arm64": "prebuildify-cross -i linux-arm64 -t 8.14.0 --napi --strip",
     "prebuild-linux-x64": "prebuildify-cross -i centos7-devtoolset7 -i alpine -t 8.14.0 --napi --strip",
     "prebuild-darwin-x64+arm64": "prebuildify -t 8.14.0 --napi --strip --arch x64+arm64",
     "prebuild-win32-x64": "prebuildify -t 8.14.0 --napi --strip",


### PR DESCRIPTION
Addresses #188. I tested using a personal fork to ensure the build succeeded—you can see the output from a successful run [here](https://github.com/sds/rocksdb/actions/runs/4081662959/jobs/7035252039).

ARM is a common developer platform, especially if you are building Docker images on Apple Silicon using Docker Desktop.

This requires the `openssl_fips` variable to be set to the empty string in a few gyp files, suggested by [this thread](https://github.com/nodejs/node-gyp/issues/2673#issuecomment-1165324060).